### PR TITLE
make delegate of RCRoom writable

### DIFF
--- a/ErizoClient/ECRoom.h
+++ b/ErizoClient/ECRoom.h
@@ -271,7 +271,7 @@ typedef NS_ENUM(NSInteger, ECRoomErrorStatus) {
 ///-----------------------------------
 
 /// ECRoomDelegate were this room will invoke methods as events.
-@property (weak, nonatomic, readonly) id <ECRoomDelegate> delegate;
+@property (weak, nonatomic) id <ECRoomDelegate> delegate;
 
 /// ECRoomStatsDelegate delegate to receive stats.
 /// Notice that you should also set *publishingStats* to YES.


### PR DESCRIPTION
Hi zevarito,

Thank you for making this library, it's awesome!! I am using this library and here I make a PR.

For easier controlling whether the ECRoomDelegate functions should be called or not, I make the delegate of ECRoom writable.

Because ECRoom has a timer, it will be dealloc after it receives "appClient:didChangeState:" (ECClientDelegate). Before the old ECRoom is dealloc, the user could connect and create a new ECRoom that makes the Manager class do the delegate functions for both the old and the new ECRoom. For unsettling the old ECRoom's delegate, I make it writeable.

I hope it's clear enough. Thank you zevarito