### PR TITLE
Add funciton prepareToDeallocByInvalidatingTimer to prevent timer to delay the deallocting of ECRoom.

### DIFF
--- a/ErizoClient/ECRoom.h
+++ b/ErizoClient/ECRoom.h
@@ -382,4 +382,11 @@ typedef NS_ENUM(NSInteger, ECRoomErrorStatus) {
  */
 - (void)leave;
 
+/**
+ Invalidate the timer.
+ 
+ If not invalidate the timer before setting ECRoom nil, the ECRoom will stay alive until the timer is being invalidated.
+ */
+- (void)prepareToDeallocByInvalidatingTimer;
+
 @end

--- a/ErizoClient/ECRoom.m
+++ b/ErizoClient/ECRoom.m
@@ -159,6 +159,10 @@ static NSString * const kRTCStatsMediaTypeKey    = @"mediaType";
     return remoteStreams;
 }
 
+- (void)prepareToDeallocByInvalidatingTimer {
+    [publishingStatsTimer invalidate];
+}
+
 #
 # pragma mark - Private
 #


### PR DESCRIPTION
This pr is related to https://github.com/zevarito/Licode-ErizoClientIOS/pull/69

The goal is to dealloc ECRoom right after we set a pointer to ECRoom nil. Or ECRoom will be dealloc later, and so its delegate will get "disconnect" state change, which we may not need.

----

I not sure this function name is good enough, please feel to modify it.

Btw, I veried that the ECRoom will be dealloc.