### PR TITLE
Feature - Add class ECCameraPreviewView

### DIFF
--- a/ErizoClient/ECCameraPreviewView.h
+++ b/ErizoClient/ECCameraPreviewView.h
@@ -12,10 +12,36 @@
 
 @interface ECCameraPreviewView : UIView
 
+///-----------------------------------
+/// @name Initializers
+///-----------------------------------
+
+/**
+Create a ECCameraPreviewView.
+
+@param frame Custom frame where this view should be rendered.
+
+@returns instancetype
+*/
 - (instancetype)initWithFrame:(CGRect)frame;
 
+/**
+ Create a ECCameraPreviewView with a local stream that is being displayed on this ECCameraPreview.
+ 
+ @param frame Custom frame where this view should be rendered.
+ 
+ @returns instancetype
+ */
+- (instancetype)initWithFrame:(CGRect)frame localStream:(ECStream *)localStream;
 
+/**
+ Setup this ECCameraPreviewView with a local stream that is being displayed on this ECCameraPreview.
+ */
 - (void)setupWithLocalStream:(ECStream *)localStream;
+
+///-----------------------------------
+/// @name Properties
+///-----------------------------------
 
 /// Local stream object that contains a media stream
 @property (strong, nonatomic, readonly) ECStream *localStream;

--- a/ErizoClient/ECCameraPreviewView.h
+++ b/ErizoClient/ECCameraPreviewView.h
@@ -1,0 +1,24 @@
+//
+//  ErizoClientIOS
+//
+//  Copyright (c) 2018 Li Lin (allenlinli@gmail.com).
+//
+//  MIT License, see LICENSE file for details.
+//
+
+#import <UIKit/UIKit.h>
+@import WebRTC;
+#import "ECStream.h"
+
+@interface ECCameraPreviewView : UIView
+
+- (instancetype)initWithFrame:(CGRect)frame;
+
+- (instancetype)initWithFrame:(CGRect)frame localStream:(ECStream *)localStream withLocalCapturer:(RTCCameraVideoCapturer *)localCapturer;
+
+- (void)setupWithLocalStream:(ECStream *)localStream;
+
+/// Local stream object that contains a media stream
+@property (strong, nonatomic, readonly) ECStream *localStream;
+
+@end

--- a/ErizoClient/ECCameraPreviewView.h
+++ b/ErizoClient/ECCameraPreviewView.h
@@ -14,7 +14,6 @@
 
 - (instancetype)initWithFrame:(CGRect)frame;
 
-- (instancetype)initWithFrame:(CGRect)frame localStream:(ECStream *)localStream withLocalCapturer:(RTCCameraVideoCapturer *)localCapturer;
 
 - (void)setupWithLocalStream:(ECStream *)localStream;
 

--- a/ErizoClient/ECCameraPreviewView.m
+++ b/ErizoClient/ECCameraPreviewView.m
@@ -26,7 +26,7 @@
     return self;
 }
 
-- (instancetype)initWithFrame:(CGRect)frame localStream:(ECStream *)localStream withLocalCapturer:(RTCCameraVideoCapturer *)localCapturer {
+- (instancetype)initWithFrame:(CGRect)frame localStream:(ECStream *)localStream {
     if (self = [self initWithFrame:frame]) {
         [self setupWithLocalStream:localStream];
     }

--- a/ErizoClient/ECCameraPreviewView.m
+++ b/ErizoClient/ECCameraPreviewView.m
@@ -34,6 +34,14 @@
 }
 
 - (void)setupWithLocalStream:(ECStream *)localStream {
+    if (localStream == nil) {
+        self.cameraPreviewView.captureSession = nil;
+        return;
+    }
+    if (!localStream.isLocal) {
+        return;
+    }
+    
     _localStream = localStream;
     
     if ([localStream.mediaStream.videoTracks.firstObject.source isKindOfClass:[RTCAVFoundationVideoSource class]]) {

--- a/ErizoClient/ECCameraPreviewView.m
+++ b/ErizoClient/ECCameraPreviewView.m
@@ -19,7 +19,8 @@
 
 - (instancetype)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
-        _cameraPreviewView = [[RTCCameraPreviewView alloc] initWithFrame:frame];
+        CGRect rect = CGRectMake(0.0, 0.0, frame.size.width, frame.size.height);
+        _cameraPreviewView = [[RTCCameraPreviewView alloc] initWithFrame:rect];
         [self addSubview:_cameraPreviewView];
     }
     return self;

--- a/ErizoClient/ECCameraPreviewView.m
+++ b/ErizoClient/ECCameraPreviewView.m
@@ -11,7 +11,6 @@
 
 @interface ECCameraPreviewView()
 
-/// Stream object that contains a media stream
 @property (strong, nonatomic, readonly) RTCCameraPreviewView *cameraPreviewView;
 
 @end

--- a/ErizoClient/ECCameraPreviewView.m
+++ b/ErizoClient/ECCameraPreviewView.m
@@ -1,0 +1,47 @@
+//
+//  ErizoClientIOS
+//
+//  Copyright (c) 2018 Li Lin (allenlinli@gmail.com).
+//
+//  MIT License, see LICENSE file for details.
+//
+
+@import WebRTC;
+#import "ECCameraPreviewView.h"
+
+@interface ECCameraPreviewView()
+
+/// Stream object that contains a media stream
+@property (strong, nonatomic, readonly) RTCCameraPreviewView *cameraPreviewView;
+
+@end
+
+@implementation ECCameraPreviewView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    if (self = [super initWithFrame:frame]) {
+        _cameraPreviewView = [[RTCCameraPreviewView alloc] initWithFrame:frame];
+        [self addSubview:_cameraPreviewView];
+    }
+    return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame localStream:(ECStream *)localStream withLocalCapturer:(RTCCameraVideoCapturer *)localCapturer {
+    if (self = [self initWithFrame:frame]) {
+        [self setupWithLocalStream:localStream];
+    }
+    return self;
+}
+
+- (void)setupWithLocalStream:(ECStream *)localStream {
+    _localStream = localStream;
+    
+    if ([localStream.mediaStream.videoTracks.firstObject.source isKindOfClass:[RTCAVFoundationVideoSource class]]) {
+        RTCAVFoundationVideoSource *videoSource = (RTCAVFoundationVideoSource *) localStream.mediaStream.videoTracks.firstObject.source;
+        self.cameraPreviewView.captureSession = videoSource.captureSession;
+    }
+}
+
+@end
+
+

--- a/ErizoClientIOS.xcodeproj/project.pbxproj
+++ b/ErizoClientIOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		78D593741B7C17FF00EDF432 /* SDPUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D593651B7C17FF00EDF432 /* SDPUtils.m */; };
 		78D593761B7C17FF00EDF432 /* ECStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D593691B7C17FF00EDF432 /* ECStream.m */; };
 		78D593771B7C17FF00EDF432 /* ECRoom.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D5936A1B7C17FF00EDF432 /* ECRoom.m */; };
+		FF0AEFDE2092BE4E000501E0 /* ECCameraPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AEFDD2092BE4E000501E0 /* ECCameraPreviewView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +124,8 @@
 		78E539CF1B99E4F4004B63EF /* CHANGELOG */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGELOG; sourceTree = "<group>"; };
 		B916C67F7DBD8F27E3B4F7F5 /* Pods-ErizoClient.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ErizoClient.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ErizoClient/Pods-ErizoClient.debug.xcconfig"; sourceTree = "<group>"; };
 		C46FE2A8E0D86F786A534622 /* Pods-ErizoClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ErizoClient.release.xcconfig"; path = "Pods/Target Support Files/Pods-ErizoClient/Pods-ErizoClient.release.xcconfig"; sourceTree = "<group>"; };
+		FF0AEFDC2092BE4E000501E0 /* ECCameraPreviewView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ECCameraPreviewView.h; sourceTree = "<group>"; };
+		FF0AEFDD2092BE4E000501E0 /* ECCameraPreviewView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ECCameraPreviewView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,6 +162,8 @@
 			isa = PBXGroup;
 			children = (
 				78D593501B7C17FF00EDF432 /* RTC */,
+				FF0AEFDC2092BE4E000501E0 /* ECCameraPreviewView.h */,
+				FF0AEFDD2092BE4E000501E0 /* ECCameraPreviewView.m */,
 				785C801A1B9DE13300DD721F /* ECPlayerView.h */,
 				785C80191B9DE13300DD721F /* ECPlayerView.m */,
 				7875E15D1B7ED6CE00BEE085 /* ErizoClient.h */,
@@ -455,6 +460,7 @@
 				785C801B1B9DE13300DD721F /* ECPlayerView.m in Sources */,
 				78D593761B7C17FF00EDF432 /* ECStream.m in Sources */,
 				78D5936F1B7C17FF00EDF432 /* ECSignalingMessage.m in Sources */,
+				FF0AEFDE2092BE4E000501E0 /* ECCameraPreviewView.m in Sources */,
 				78D593711B7C17FF00EDF432 /* RTCIceCandidate+JSON.m in Sources */,
 				78D593721B7C17FF00EDF432 /* RTCIceServer+JSON.m in Sources */,
 				78D593731B7C17FF00EDF432 /* RTCSessionDescription+JSON.m in Sources */,


### PR DESCRIPTION
Hi zevarito,

I add a new class `ECCameraPreviewView` to provide a mirror stream view.
It's based on `RTCCameraPreviewView`, which is used in demo code "APP RTC Mobile iOS"
- https://github.com/WebKit/webkit/tree/master/Source/ThirdParty/libwebrtc/Source/webrtc/examples/objc/AppRTCMobile/ios
- https://github.com/jasonchuang/AppRTCMobileIOS

Please feel free to suggest it on code review, or open a pull request on this pull request to modify it :)

----
Notes:

- I considered using "mirror" property on `ECPlayerView` by making RTCEAGLVideoView or its layer mirrored. I may give another PR for its implementation later.
- I didn't provide `RTCEAGLVideoViewDelegate` now since I don't know how to connect it so far.
- It's interesting that we have class `RTCCameraPreviewView`, which is based on `AVCaptureVideoPreviewLayer `(https://goo.gl/Vw355f). I wonder why do we need a capture session especially, and why do WebRTC provide `RTCCameraPreviewView`, not a mirror property on `RTCEAGLVideoView` (https://goo.gl/84u6To)? I ask for a feature request on WebRTC already (https://bugs.chromium.org/p/webrtc/issues/detail?id=9164), but I think our PR goes faster.

Cheers.