### PR TITLE
fix: do ECClient disconnect in RTCIceConnectionStateClosed only to prevent crash.

### DIFF
--- a/ErizoClient/rtc/ECClient.m
+++ b/ErizoClient/rtc/ECClient.m
@@ -260,8 +260,10 @@ readyToSubscribeStreamId:(NSString *)streamId
                 L_WARNING(@"RTCIceConnectionStateFailed %@", peerConnection);
                 break;
             }
-            case RTCIceConnectionStateClosed:
             case RTCIceConnectionStateDisconnected: {
+                break;
+            }
+            case RTCIceConnectionStateClosed: {
                 [self disconnect];
                 break;
             }


### PR DESCRIPTION
I found a bug that it crashes when I disconnect a room.
The bug is described in the issue I sent earlier: https://github.com/zevarito/Licode-ErizoClientIOS/issues/74

I found the reason it crashes is that a block inside ECClient is being released when the ECClient is released(while ECRoom's `publishingStatsTimer` released, and so that ECRoom and ECClient are released).

So I move the `disconnect` to RTCIceConnectionStateClosed to prevent this crash.

And after I read the references addressed in this issue (https://github.com/zevarito/Licode-ErizoClientIOS/issues/73), I still didn't find should both `RTCIceConnectionStateDisconnected` and  `RTCIceConnectionStateClosed` do `disconnect`. Since disconnect deallocates `ECRoom`, and it "probably" always calls `RTCIceConnectionStateClosed`, we could safely call `disconnect` at `RTCIceConnectionStateClosed`.