### PR TITLE
feature/implementOnUnpublishCallbackEtc

### DIFF
--- a/ErizoClient/ECRoom.h
+++ b/ErizoClient/ECRoom.h
@@ -150,12 +150,13 @@ typedef NS_ENUM(NSInteger, ECRoomErrorStatus) {
  
  @param room Instance of the room where event happen.
  @param status Status constant
- @param reason Text explaining the error. (Not always available)
+ @param error Text explaining the error. (Not always available)
  
  */
 - (void)room:(ECRoom *)room
-    didError:(ECRoomErrorStatus)status
-      reason:(NSString *)reason;
+    didError:(NSError *)error
+      status:(ECRoomErrorStatus)status;
+
 
 /**
  Fired each time the room changed his state.

--- a/ErizoClient/ECRoom.m
+++ b/ErizoClient/ECRoom.m
@@ -228,8 +228,8 @@ static NSString * const kRTCStatsMediaTypeKey    = @"mediaType";
     return client;
 }
 
-- (void)signalingChannel:(ECSignalingChannel *)channel didError:(NSString *)reason {
-    [_delegate room:self didError:ECRoomErrorSignaling reason:reason];
+- (void)signalingChannel:(ECSignalingChannel *)channel didError:(NSError *)error {
+    [_delegate room:self didError:error status:ECRoomErrorSignaling];
     self.status = ECRoomStatusError;
 }
 
@@ -402,11 +402,11 @@ static NSString * const kRTCStatsMediaTypeKey    = @"mediaType";
 
 - (void)appClient:(ECClient *)client didError:(NSError *)error {
     L_ERROR(@"Room: Client error: %@", error.userInfo);
-    ECRoomErrorStatus roomError = ECRoomErrorClient;
+    ECRoomErrorStatus roomErrorStatus = ECRoomErrorClient;
     if (error.code == kECAppClientErrorSetSDP) {
-        roomError = ECRoomErrorClientFailedSDP;
+        roomErrorStatus = ECRoomErrorClientFailedSDP;
     }
-    [_delegate room:self didError:roomError reason:[error.userInfo description]];
+    [_delegate room:self didError:error status:roomErrorStatus];
 }
 
 # pragma mark - RTC Stats

--- a/ErizoClient/rtc/ECClient.m
+++ b/ErizoClient/rtc/ECClient.m
@@ -177,9 +177,6 @@
     }
 }
 
-- (void)signalingChannelPublishFailed:(ECSignalingChannel *)signalingChannel {
-}
-
 - (void)signalingChannel:(ECSignalingChannel *)channel
 readyToSubscribeStreamId:(NSString *)streamId
             peerSocketId:(NSString *)peerSocketId {

--- a/ErizoClient/rtc/ECSignalingChannel.h
+++ b/ErizoClient/rtc/ECSignalingChannel.h
@@ -49,13 +49,6 @@
             peerSocketId:(NSString *)peerSocketId;
 
 /**
- Event fired when Erizo failed to publishing stream.
- 
- @param signalingChannel ECSignalingChannel the channel that emit the message.
- */
-- (void)signalingChannelPublishFailed:(ECSignalingChannel *)signalingChannel;
-
-/**
  Event fired each time ECSignalingChannel has received a confirmation from the server
  to subscribe a stream.
  This event is fired to let Client know that it can start signaling to subscribe the stream.
@@ -80,9 +73,9 @@ readyToSubscribeStreamId:(NSString *)streamId
  This event is fired when a token was not successfuly used.
  
  @param channel ECSignalingChannel the channel that emit the message.
- @param reason String of error returned by the server.
+ @param error Error returned by the server.
  */
-- (void)signalingChannel:(ECSignalingChannel *)channel didError:(NSString *)reason;
+- (void)signalingChannel:(ECSignalingChannel *)channel didError:(NSError *)error;
 
 /**
  Event fired as soon a client connect to a room.

--- a/ErizoClient/rtc/ECSignalingChannel.m
+++ b/ErizoClient/rtc/ECSignalingChannel.m
@@ -373,7 +373,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ([[NSString stringWithFormat:@"NO ACK"] isEqualToString:ackString]) {
             NSString *errorString = @"No ACK received when publishing stream!";
             L_ERROR(errorString);
-            NSError *error = [NSError ECSignalingChannelErrorCodePublishWithMessage:errorString];
+            NSError *error = [NSError ECSignalingChannelErrorCodePublishWith:signalingDelegate.streamId withMessage:errorString];
             [self.roomDelegate signalingChannel:self didError:error];
             return;
         }
@@ -381,7 +381,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         // Get streamId for the stream to publish.
 		id object = [argsData objectAtIndex:0];
 		if(!object || object == [NSNull null]) {
-            NSError *error = [NSError ECSignalingChannelErrorCodePublishWithMessage:[argsData objectAtIndex:1]];
+            NSError *error = [NSError ECSignalingChannelErrorCodePublishWith:signalingDelegate.streamId withMessage:[argsData objectAtIndex:1]];
             [self.roomDelegate signalingChannel:self didError:error];
 			return;
 		}
@@ -409,7 +409,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ((BOOL)[response objectAtIndex:0]) {
             [_roomDelegate signalingChannel:self didUnpublishStreamWithId:streamId];
         } else {
-            NSError *error = [NSError ECSignalingChannelErrorCodeUnpublishWithMessage:streamId];
+            NSError *error = [NSError ECSignalingChannelErrorCodeUnpublishWith:streamId withMessage:nil];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };

--- a/ErizoClient/rtc/ECSignalingChannel.m
+++ b/ErizoClient/rtc/ECSignalingChannel.m
@@ -81,7 +81,7 @@ typedef void(^SocketIOCallback)(NSArray* data);
     [socketIO on:@"error" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull emitter) {
         L_ERROR(@"Websocket error: %@", data);
         NSString *dataString = [NSString stringWithFormat:@"%@", data];
-        NSError *error = [NSError ECSignalingChannelErrorCodeWebsocketWithMessage:dataString];
+        NSError *error = [NSError ECSignalingChannelWebsocketErrorWithMessage:dataString];
         [self.roomDelegate signalingChannel:self didError:error];
     }];
     [socketIO on:@"reconnect" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull emitter) {
@@ -358,7 +358,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
             [signalingDelegate signalingChannelDidOpenChannel:self];
             [signalingDelegate signalingChannel:self readyToSubscribeStreamId:streamId peerSocketId:nil];
         } else {
-            NSError *error = [NSError ECSignalingChannelErrorCodeSubscribeWithStreamId:streamId withMessage:nil];
+            NSError *error = [NSError ECSignalingChannelSubscribeErrorWithStreamId:streamId withMessage:nil];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };
@@ -373,7 +373,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ([[NSString stringWithFormat:@"NO ACK"] isEqualToString:ackString]) {
             NSString *errorString = @"No ACK received when publishing stream!";
             L_ERROR(errorString);
-            NSError *error = [NSError ECSignalingChannelErrorCodePublishWithStreamId:signalingDelegate.streamId withMessage:errorString];
+            NSError *error = [NSError ECSignalingChannelPublishErrorWithStreamId:signalingDelegate.streamId withMessage:errorString];
             [self.roomDelegate signalingChannel:self didError:error];
             return;
         }
@@ -381,7 +381,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         // Get streamId for the stream to publish.
 		id object = [argsData objectAtIndex:0];
 		if(!object || object == [NSNull null]) {
-            NSError *error = [NSError ECSignalingChannelErrorCodePublishWithStreamId:signalingDelegate.streamId withMessage:[argsData objectAtIndex:1]];
+            NSError *error = [NSError ECSignalingChannelPublishErrorWithStreamId:signalingDelegate.streamId withMessage:[argsData objectAtIndex:1]];
             [self.roomDelegate signalingChannel:self didError:error];
 			return;
 		}
@@ -409,7 +409,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ((BOOL)[response objectAtIndex:0]) {
             [_roomDelegate signalingChannel:self didUnpublishStreamWithId:streamId];
         } else {
-            NSError *error = [NSError ECSignalingChannelErrorCodeUnpublishWithStreamId:streamId withMessage:nil];
+            NSError *error = [NSError ECSignalingChannelUnpublishErrorWithStreamId:streamId withMessage:nil];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };
@@ -424,7 +424,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ((BOOL)[response objectAtIndex:0]) {
             [_roomDelegate signalingChannel:self didUnsubscribeStreamWithId:streamId];
         } else {
-            NSError *error = [NSError ECSignalingChannelErrorCodeUnsubscribeWithStreamId:streamId withMessage:nil];
+            NSError *error = [NSError ECSignalingChannelUnsubscribeErrorWithStreamId:streamId withMessage:nil];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };
@@ -453,7 +453,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
             }
             [_roomDelegate signalingChannel:self didConnectToRoom:roomMetadata];
         } else {
-            NSError *error = [NSError ECSignalingChannelErrorCodeSendTokenWithMessage:message];
+            NSError *error = [NSError ECSignalingChannelSendTokenErrorWithMessage:message];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };

--- a/ErizoClient/rtc/ECSignalingChannel.m
+++ b/ErizoClient/rtc/ECSignalingChannel.m
@@ -358,7 +358,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
             [signalingDelegate signalingChannelDidOpenChannel:self];
             [signalingDelegate signalingChannel:self readyToSubscribeStreamId:streamId peerSocketId:nil];
         } else {
-            NSError *error = [NSError ECSignalingChannelErrorCodeSubscribeWith:streamId withMessage:nil];
+            NSError *error = [NSError ECSignalingChannelErrorCodeSubscribeWithStreamId:streamId withMessage:nil];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };
@@ -373,7 +373,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ([[NSString stringWithFormat:@"NO ACK"] isEqualToString:ackString]) {
             NSString *errorString = @"No ACK received when publishing stream!";
             L_ERROR(errorString);
-            NSError *error = [NSError ECSignalingChannelErrorCodePublishWith:signalingDelegate.streamId withMessage:errorString];
+            NSError *error = [NSError ECSignalingChannelErrorCodePublishWithStreamId:signalingDelegate.streamId withMessage:errorString];
             [self.roomDelegate signalingChannel:self didError:error];
             return;
         }
@@ -381,7 +381,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         // Get streamId for the stream to publish.
 		id object = [argsData objectAtIndex:0];
 		if(!object || object == [NSNull null]) {
-            NSError *error = [NSError ECSignalingChannelErrorCodePublishWith:signalingDelegate.streamId withMessage:[argsData objectAtIndex:1]];
+            NSError *error = [NSError ECSignalingChannelErrorCodePublishWithStreamId:signalingDelegate.streamId withMessage:[argsData objectAtIndex:1]];
             [self.roomDelegate signalingChannel:self didError:error];
 			return;
 		}
@@ -409,7 +409,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ((BOOL)[response objectAtIndex:0]) {
             [_roomDelegate signalingChannel:self didUnpublishStreamWithId:streamId];
         } else {
-            NSError *error = [NSError ECSignalingChannelErrorCodeUnpublishWith:streamId withMessage:nil];
+            NSError *error = [NSError ECSignalingChannelErrorCodeUnpublishWithStreamId:streamId withMessage:nil];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };
@@ -424,7 +424,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ((BOOL)[response objectAtIndex:0]) {
             [_roomDelegate signalingChannel:self didUnsubscribeStreamWithId:streamId];
         } else {
-            NSError *error = [NSError ECSignalingChannelErrorCodeUnsubscribeWith:streamId withMessage:nil];
+            NSError *error = [NSError ECSignalingChannelErrorCodeUnsubscribeWithStreamId:streamId withMessage:nil];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };

--- a/ErizoClient/rtc/ECSignalingChannel.m
+++ b/ErizoClient/rtc/ECSignalingChannel.m
@@ -358,7 +358,8 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
             [signalingDelegate signalingChannelDidOpenChannel:self];
             [signalingDelegate signalingChannel:self readyToSubscribeStreamId:streamId peerSocketId:nil];
         } else {
-            L_ERROR(@"SignalingChannel couldn't subscribe streamId: %@", streamId);
+            NSError *error = [NSError ECSignalingChannelErrorCodeSubscribeWith:streamId withMessage:nil];
+            [self.roomDelegate signalingChannel:self didError:error];
         }
     };
     return _cb;
@@ -408,7 +409,8 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ((BOOL)[response objectAtIndex:0]) {
             [_roomDelegate signalingChannel:self didUnpublishStreamWithId:streamId];
         } else {
-            L_ERROR(@"signalingChannel Couldn't unpublish stream id: %@", streamId);
+            NSError *error = [NSError ECSignalingChannelErrorCodeUnpublishWithMessage:streamId];
+            [self.roomDelegate signalingChannel:self didError:error];
         }
     };
     return _cb;
@@ -422,7 +424,8 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ((BOOL)[response objectAtIndex:0]) {
             [_roomDelegate signalingChannel:self didUnsubscribeStreamWithId:streamId];
         } else {
-            L_ERROR(@"signalingChannel Couldn't unsubscribe stream id: %@", streamId);
+            NSError *error = [NSError ECSignalingChannelErrorCodeUnsubscribeWith:streamId withMessage:nil];
+            [self.roomDelegate signalingChannel:self didError:error];
         }
     };
     return _cb;

--- a/ErizoClient/rtc/ECSignalingChannel.m
+++ b/ErizoClient/rtc/ECSignalingChannel.m
@@ -81,7 +81,7 @@ typedef void(^SocketIOCallback)(NSArray* data);
     [socketIO on:@"error" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull emitter) {
         L_ERROR(@"Websocket error: %@", data);
         NSString *dataString = [NSString stringWithFormat:@"%@", data];
-        NSError *error = [NSError ECSignalingChannelWebsocketErrorWithMessage:dataString];
+        NSError *error = [NSError ECSignalingChannelErrorCodeWebsocketWithMessage:dataString];
         [self.roomDelegate signalingChannel:self didError:error];
     }];
     [socketIO on:@"reconnect" callback:^(NSArray * _Nonnull data, SocketAckEmitter * _Nonnull emitter) {
@@ -372,7 +372,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         if ([[NSString stringWithFormat:@"NO ACK"] isEqualToString:ackString]) {
             NSString *errorString = @"No ACK received when publishing stream!";
             L_ERROR(errorString);
-            NSError *error = [NSError ECSignalingChannelPublishErrorWithMessage:errorString];
+            NSError *error = [NSError ECSignalingChannelErrorCodePublishWithMessage:errorString];
             [self.roomDelegate signalingChannel:self didError:error];
             return;
         }
@@ -380,7 +380,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
         // Get streamId for the stream to publish.
 		id object = [argsData objectAtIndex:0];
 		if(!object || object == [NSNull null]) {
-            NSError *error = [NSError ECSignalingChannelPublishErrorWithMessage:[argsData objectAtIndex:1]];
+            NSError *error = [NSError ECSignalingChannelErrorCodePublishWithMessage:[argsData objectAtIndex:1]];
             [self.roomDelegate signalingChannel:self didError:error];
 			return;
 		}
@@ -450,7 +450,7 @@ signalingChannelDelegate:(id<ECSignalingChannelDelegate>)delegate {
             }
             [_roomDelegate signalingChannel:self didConnectToRoom:roomMetadata];
         } else {
-            NSError *error = [NSError ECSignalingChannelSendTokenErrorWithMessage:message];
+            NSError *error = [NSError ECSignalingChannelErrorCodeSendTokenWithMessage:message];
             [self.roomDelegate signalingChannel:self didError:error];
         }
     };

--- a/ErizoClient/rtc/ECSignalingChannelErrorCode.h
+++ b/ErizoClient/rtc/ECSignalingChannelErrorCode.h
@@ -1,0 +1,22 @@
+//
+//  ErizoClientIOS
+//
+//  Copyright (c) 2015 Alvaro Gil (zevarito@gmail.com).
+//
+//  MIT License, see LICENSE file for details.
+//
+
+#ifndef ECSignalingChannelErrorCode_h
+#define ECSignalingChannelErrorCode_h
+
+typedef NS_ENUM(NSUInteger, ECSignalingChannelErrorCode) {
+    ECSignalingChannelConnectError = 0,
+    ECSignalingChannelPublishError = 1,
+    ECSignalingChannelUnpublishError = 2,
+    ECSignalingChannelSubscribeError = 3,
+    ECSignalingChannelUnsubscribeError = 4,
+    ECSignalingChannelSendTokenError = 5,
+    ECSignalingChannelWebsocketError = 6,
+};
+
+#endif /* ECSignalingChannelErrorCode_h */

--- a/ErizoClient/rtc/ECSignalingChannelErrorCode.h
+++ b/ErizoClient/rtc/ECSignalingChannelErrorCode.h
@@ -10,13 +10,13 @@
 #define ECSignalingChannelErrorCode_h
 
 typedef NS_ENUM(NSUInteger, ECSignalingChannelErrorCode) {
-    ECSignalingChannelConnectError = 0,
-    ECSignalingChannelPublishError = 1,
-    ECSignalingChannelUnpublishError = 2,
-    ECSignalingChannelSubscribeError = 3,
-    ECSignalingChannelUnsubscribeError = 4,
-    ECSignalingChannelSendTokenError = 5,
-    ECSignalingChannelWebsocketError = 6,
+    ECSignalingChannelErrorCodeConnect = 0,
+    ECSignalingChannelErrorCodePublish = 1,
+    ECSignalingChannelErrorCodeUnpublish = 2,
+    ECSignalingChannelErrorCodeSubscribe = 3,
+    ECSignalingChannelErrorCodeUnsubscribe = 4,
+    ECSignalingChannelErrorCodeSendToken = 5,
+    ECSignalingChannelErrorCodeWebsocket = 6,
 };
 
 #endif /* ECSignalingChannelErrorCode_h */

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.h
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.h
@@ -18,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)ECSignalingChannelErrorCodeConnectWithMessage:(NSString *)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodePublishWithMessage:(NSString *)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodeUnpublishWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodeSendTokenWithMessage:(NSString *)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodeWebsocketWithMessage:(NSString *)errorMessage;
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.h
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.h
@@ -15,13 +15,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSError (ECSignalingChannel)
 
-+ (instancetype)ECSignalingChannelConnectErrorWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelPublishErrorWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelUnpublishErrorWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelSubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelUnsubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelSendTokenErrorWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelWebsocketErrorWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeConnectWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodePublishWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeUnpublishWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeSendTokenWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeWebsocketWithMessage:(NSString *)errorMessage;
 
 @end
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.h
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.h
@@ -17,8 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSError (ECSignalingChannel)
 
 + (instancetype)ECSignalingChannelErrorCodeConnectWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodePublishWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeUnpublishWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodePublishWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeUnpublishWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodeSendTokenWithMessage:(NSString *)errorMessage;

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.h
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.h
@@ -10,6 +10,7 @@
 #import "ECStream.h"
 
 FOUNDATION_EXPORT NSString * const ECSignalingChannelErrorDomain;
+FOUNDATION_EXPORT NSString * const ECSignalingChannelErrorUserInfoKeyStreamId;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.h
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.h
@@ -1,0 +1,17 @@
+//
+//  ErizoClientIOS
+//
+//  Copyright (c) 2015 Alvaro Gil (zevarito@gmail.com).
+//
+//  MIT License, see LICENSE file for details.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSError (ECSignalingChannel)
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.h
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.h
@@ -16,13 +16,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSError (ECSignalingChannel)
 
-+ (instancetype)ECSignalingChannelErrorCodeConnectWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodePublishWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeUnpublishWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeSubscribeWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeSendTokenWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeWebsocketWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelConnectErrorWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelPublishErrorWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelUnpublishErrorWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelSubscribeErrorWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelUnsubscribeErrorWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelSendTokenErrorWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelWebsocketErrorWithMessage:(NSString *)errorMessage;
 
 @end
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.h
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.h
@@ -17,10 +17,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSError (ECSignalingChannel)
 
 + (instancetype)ECSignalingChannelErrorCodeConnectWithMessage:(NSString *)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodePublishWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeUnpublishWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
-+ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodePublishWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeUnpublishWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeSubscribeWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
++ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodeSendTokenWithMessage:(NSString *)errorMessage;
 + (instancetype)ECSignalingChannelErrorCodeWebsocketWithMessage:(NSString *)errorMessage;
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.h
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.h
@@ -7,10 +7,21 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "ECStream.h"
+
+FOUNDATION_EXPORT NSString * const ECSignalingChannelErrorDomain;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NSError (ECSignalingChannel)
+
++ (instancetype)ECSignalingChannelConnectErrorWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelPublishErrorWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelUnpublishErrorWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelSubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelUnsubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelSendTokenErrorWithMessage:(NSString *)errorMessage;
++ (instancetype)ECSignalingChannelWebsocketErrorWithMessage:(NSString *)errorMessage;
 
 @end
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -7,37 +7,38 @@
 //
 
 #import "NSError+ECSignalingChannel.h"
+#import "ECSignalingChannelErrorCode.h"
 
 NSString * const ECSignalingChannelErrorDomain = @"ECSignalingChannelErrorDomain";
 
 @implementation NSError (ECSignalingChannel)
 
 + (instancetype)ECSignalingChannelConnectErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelConnectError];
 }
 
 + (instancetype)ECSignalingChannelPublishErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelPublishError];
 }
 
 + (instancetype)ECSignalingChannelUnpublishErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelUnpublishError];
 }
 
 + (instancetype)ECSignalingChannelSubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelSubscribeError];
 }
 
 + (instancetype)ECSignalingChannelUnsubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelUnsubscribeError];
 }
 
 + (instancetype)ECSignalingChannelSendTokenErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelSendTokenError];
 }
 
 + (instancetype)ECSignalingChannelWebsocketErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelWebsocketError];
 }
 
 #pragma mark - Private Methods

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -18,11 +18,11 @@ NSString * const ECSignalingChannelErrorUserInfoKeyStreamId = @"streamId";
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeConnect];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodePublishWithMessage:(NSString *)errorMessage {
++ (instancetype)ECSignalingChannelErrorCodePublishWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodePublish];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeUnpublishWithMessage:(NSString *)errorMessage {
++ (instancetype)ECSignalingChannelErrorCodeUnpublishWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeUnpublish];
 }
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -10,6 +10,7 @@
 #import "ECSignalingChannelErrorCode.h"
 
 NSString * const ECSignalingChannelErrorDomain = @"ECSignalingChannelErrorDomain";
+NSString * const ECSignalingChannelErrorUserInfoKeyStreamId = @"streamId";
 
 @implementation NSError (ECSignalingChannel)
 
@@ -50,7 +51,7 @@ NSString * const ECSignalingChannelErrorDomain = @"ECSignalingChannelErrorDomain
 + (NSError *)ECSignalingChannelErrorWithErrorString:(NSString *)errorMessage streamId:(NSString *)streamId code:(NSInteger)code {
     NSMutableDictionary * userInfo = [@{NSLocalizedDescriptionKey: errorMessage} mutableCopy];
     if (streamId) {
-        [userInfo setObject:streamId forKey:@"streamId"];
+        [userInfo setObject:streamId forKey:ECSignalingChannelErrorUserInfoKeyStreamId];
     }
     NSError *error = [NSError errorWithDomain:ECSignalingChannelErrorDomain
                                          code:code

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -1,0 +1,13 @@
+//
+//  ErizoClientIOS
+//
+//  Copyright (c) 2015 Alvaro Gil (zevarito@gmail.com).
+//
+//  MIT License, see LICENSE file for details.
+//
+
+#import "NSError+ECSignalingChannel.h"
+
+@implementation NSError (ECSignalingChannel)
+
+@end

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -13,32 +13,32 @@ NSString * const ECSignalingChannelErrorDomain = @"ECSignalingChannelErrorDomain
 
 @implementation NSError (ECSignalingChannel)
 
-+ (instancetype)ECSignalingChannelConnectErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelConnectError];
++ (instancetype)ECSignalingChannelErrorCodeConnectWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeConnect];
 }
 
-+ (instancetype)ECSignalingChannelPublishErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelPublishError];
++ (instancetype)ECSignalingChannelErrorCodePublishWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodePublish];
 }
 
-+ (instancetype)ECSignalingChannelUnpublishErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelUnpublishError];
++ (instancetype)ECSignalingChannelErrorCodeUnpublishWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeUnpublish];
 }
 
-+ (instancetype)ECSignalingChannelSubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelSubscribeError];
++ (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeSubscribe];
 }
 
-+ (instancetype)ECSignalingChannelUnsubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelUnsubscribeError];
++ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeUnsubscribe];
 }
 
-+ (instancetype)ECSignalingChannelSendTokenErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelSendTokenError];
++ (instancetype)ECSignalingChannelErrorCodeSendTokenWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeSendToken];
 }
 
-+ (instancetype)ECSignalingChannelWebsocketErrorWithMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelWebsocketError];
++ (instancetype)ECSignalingChannelErrorCodeWebsocketWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeWebsocket];
 }
 
 #pragma mark - Private Methods

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -18,19 +18,19 @@ NSString * const ECSignalingChannelErrorUserInfoKeyStreamId = @"streamId";
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeConnect];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodePublishWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
++ (instancetype)ECSignalingChannelErrorCodePublishWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodePublish];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeUnpublishWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
++ (instancetype)ECSignalingChannelErrorCodeUnpublishWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeUnpublish];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
++ (instancetype)ECSignalingChannelErrorCodeSubscribeWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage streamId:streamId code:ECSignalingChannelErrorCodeSubscribe];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
++ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage streamId:streamId code:ECSignalingChannelErrorCodeUnsubscribe];
 }
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -14,31 +14,31 @@ NSString * const ECSignalingChannelErrorUserInfoKeyStreamId = @"streamId";
 
 @implementation NSError (ECSignalingChannel)
 
-+ (instancetype)ECSignalingChannelErrorCodeConnectWithMessage:(NSString *)errorMessage {
++ (instancetype)ECSignalingChannelConnectErrorWithMessage:(NSString *)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeConnect];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodePublishWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
++ (instancetype)ECSignalingChannelPublishErrorWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodePublish];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeUnpublishWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
++ (instancetype)ECSignalingChannelUnpublishErrorWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeUnpublish];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeSubscribeWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
++ (instancetype)ECSignalingChannelSubscribeErrorWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage streamId:streamId code:ECSignalingChannelErrorCodeSubscribe];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
++ (instancetype)ECSignalingChannelUnsubscribeErrorWithStreamId:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage streamId:streamId code:ECSignalingChannelErrorCodeUnsubscribe];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeSendTokenWithMessage:(NSString *)errorMessage {
++ (instancetype)ECSignalingChannelSendTokenErrorWithMessage:(NSString *)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeSendToken];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeWebsocketWithMessage:(NSString *)errorMessage {
++ (instancetype)ECSignalingChannelWebsocketErrorWithMessage:(NSString *)errorMessage {
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeWebsocket];
 }
 

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -8,6 +8,46 @@
 
 #import "NSError+ECSignalingChannel.h"
 
+NSString * const ECSignalingChannelErrorDomain = @"ECSignalingChannelErrorDomain";
+
 @implementation NSError (ECSignalingChannel)
+
++ (instancetype)ECSignalingChannelConnectErrorWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+}
+
++ (instancetype)ECSignalingChannelPublishErrorWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+}
+
++ (instancetype)ECSignalingChannelUnpublishErrorWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+}
+
++ (instancetype)ECSignalingChannelSubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+}
+
++ (instancetype)ECSignalingChannelUnsubscribeErrorWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+}
+
++ (instancetype)ECSignalingChannelSendTokenErrorWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+}
+
++ (instancetype)ECSignalingChannelWebsocketErrorWithMessage:(NSString *)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:0];
+}
+
+#pragma mark - Private Methods
+
++ (NSError *)ECSignalingChannelErrorWithErrorString:(NSString *)errorMessage code:(NSInteger)code {
+    NSDictionary * userInfo = @{NSLocalizedDescriptionKey: errorMessage};
+    NSError *error = [NSError errorWithDomain:ECSignalingChannelErrorDomain
+                                         code:code
+                                     userInfo:userInfo];
+    return error;
+}
 
 @end

--- a/ErizoClient/rtc/NSError+ECSignalingChannel.m
+++ b/ErizoClient/rtc/NSError+ECSignalingChannel.m
@@ -25,12 +25,12 @@ NSString * const ECSignalingChannelErrorDomain = @"ECSignalingChannelErrorDomain
     return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeUnpublish];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeSubscribe];
++ (instancetype)ECSignalingChannelErrorCodeSubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage streamId:streamId code:ECSignalingChannelErrorCodeSubscribe];
 }
 
-+ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString *)errorMessage {
-    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage code:ECSignalingChannelErrorCodeUnsubscribe];
++ (instancetype)ECSignalingChannelErrorCodeUnsubscribeWith:(NSString *)streamId withMessage:(NSString * _Nullable)errorMessage {
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage streamId:streamId code:ECSignalingChannelErrorCodeUnsubscribe];
 }
 
 + (instancetype)ECSignalingChannelErrorCodeSendTokenWithMessage:(NSString *)errorMessage {
@@ -44,10 +44,17 @@ NSString * const ECSignalingChannelErrorDomain = @"ECSignalingChannelErrorDomain
 #pragma mark - Private Methods
 
 + (NSError *)ECSignalingChannelErrorWithErrorString:(NSString *)errorMessage code:(NSInteger)code {
-    NSDictionary * userInfo = @{NSLocalizedDescriptionKey: errorMessage};
+    return [NSError ECSignalingChannelErrorWithErrorString:errorMessage streamId:nil code:code];
+}
+
++ (NSError *)ECSignalingChannelErrorWithErrorString:(NSString *)errorMessage streamId:(NSString *)streamId code:(NSInteger)code {
+    NSMutableDictionary * userInfo = [@{NSLocalizedDescriptionKey: errorMessage} mutableCopy];
+    if (streamId) {
+        [userInfo setObject:streamId forKey:@"streamId"];
+    }
     NSError *error = [NSError errorWithDomain:ECSignalingChannelErrorDomain
                                          code:code
-                                     userInfo:userInfo];
+                                     userInfo:[userInfo copy]];
     return error;
 }
 

--- a/ErizoClientIOS.xcodeproj/project.pbxproj
+++ b/ErizoClientIOS.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		78D593741B7C17FF00EDF432 /* SDPUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D593651B7C17FF00EDF432 /* SDPUtils.m */; };
 		78D593761B7C17FF00EDF432 /* ECStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D593691B7C17FF00EDF432 /* ECStream.m */; };
 		78D593771B7C17FF00EDF432 /* ECRoom.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D5936A1B7C17FF00EDF432 /* ECRoom.m */; };
+		FFC8E03420D24F340027EDEF /* NSError+ECSignalingChannel.m in Sources */ = {isa = PBXBuildFile; fileRef = FFC8E03320D24F340027EDEF /* NSError+ECSignalingChannel.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +124,8 @@
 		78E539CF1B99E4F4004B63EF /* CHANGELOG */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CHANGELOG; sourceTree = "<group>"; };
 		B916C67F7DBD8F27E3B4F7F5 /* Pods-ErizoClient.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ErizoClient.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ErizoClient/Pods-ErizoClient.debug.xcconfig"; sourceTree = "<group>"; };
 		C46FE2A8E0D86F786A534622 /* Pods-ErizoClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ErizoClient.release.xcconfig"; path = "Pods/Target Support Files/Pods-ErizoClient/Pods-ErizoClient.release.xcconfig"; sourceTree = "<group>"; };
+		FFC8E03220D24F340027EDEF /* NSError+ECSignalingChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+ECSignalingChannel.h"; sourceTree = "<group>"; };
+		FFC8E03320D24F340027EDEF /* NSError+ECSignalingChannel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+ECSignalingChannel.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +259,8 @@
 				781DA3F91E6AF0AF005670A2 /* ECClientDelegate.h */,
 				781DA3FA1E6B1AC7005670A2 /* ECClientState.h */,
 				78D593511B7C17FF00EDF432 /* ECClient+Internal.h */,
+				FFC8E03220D24F340027EDEF /* NSError+ECSignalingChannel.h */,
+				FFC8E03320D24F340027EDEF /* NSError+ECSignalingChannel.m */,
 				78D593571B7C17FF00EDF432 /* ECSignalingChannel.h */,
 				78D593581B7C17FF00EDF432 /* ECSignalingChannel.m */,
 				78D593591B7C17FF00EDF432 /* ECSignalingMessage.h */,
@@ -457,6 +462,7 @@
 				78D5936F1B7C17FF00EDF432 /* ECSignalingMessage.m in Sources */,
 				78D593711B7C17FF00EDF432 /* RTCIceCandidate+JSON.m in Sources */,
 				78D593721B7C17FF00EDF432 /* RTCIceServer+JSON.m in Sources */,
+				FFC8E03420D24F340027EDEF /* NSError+ECSignalingChannel.m in Sources */,
 				78D593731B7C17FF00EDF432 /* RTCSessionDescription+JSON.m in Sources */,
 				78D5936C1B7C17FF00EDF432 /* ECClient.m in Sources */,
 				78D5936E1B7C17FF00EDF432 /* ECSignalingChannel.m in Sources */,

--- a/ErizoClientIOS.xcodeproj/project.pbxproj
+++ b/ErizoClientIOS.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		C46FE2A8E0D86F786A534622 /* Pods-ErizoClient.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ErizoClient.release.xcconfig"; path = "Pods/Target Support Files/Pods-ErizoClient/Pods-ErizoClient.release.xcconfig"; sourceTree = "<group>"; };
 		FFC8E03220D24F340027EDEF /* NSError+ECSignalingChannel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+ECSignalingChannel.h"; sourceTree = "<group>"; };
 		FFC8E03320D24F340027EDEF /* NSError+ECSignalingChannel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+ECSignalingChannel.m"; sourceTree = "<group>"; };
+		FFC8E03720D2563A0027EDEF /* ECSignalingChannelErrorCode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ECSignalingChannelErrorCode.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -259,6 +260,7 @@
 				781DA3F91E6AF0AF005670A2 /* ECClientDelegate.h */,
 				781DA3FA1E6B1AC7005670A2 /* ECClientState.h */,
 				78D593511B7C17FF00EDF432 /* ECClient+Internal.h */,
+				FFC8E03720D2563A0027EDEF /* ECSignalingChannelErrorCode.h */,
 				FFC8E03220D24F340027EDEF /* NSError+ECSignalingChannel.h */,
 				FFC8E03320D24F340027EDEF /* NSError+ECSignalingChannel.m */,
 				78D593571B7C17FF00EDF432 /* ECSignalingChannel.h */,

--- a/ErizoClientIOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ErizoClientIOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
- Handle error for unpublish/subscribe/unsubscribe (https://github.com/zevarito/Licode-ErizoClientIOS/issues/76)
    - Refactor to return NSError instead of error reason string in ECSignalingChannelRoomDelegate and ECRoomDelegate.
    - Add ECSignalingChannelErrorCode.